### PR TITLE
prevent KeyError in `build_track_add`

### DIFF
--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -827,7 +827,8 @@ class BatchMutateTracks(McBatchMutateCall):
                     'albumAvailableForPurchase', 'albumArtRef',
                     'artistId',
                     ):
-            del track_dict[key]
+            if key in track_dict:
+                del track_dict[key]
 
         for key, default in {
             'playCount': 0,


### PR DESCRIPTION
Certain tracks (like Tp3e52picsj55ozzmjtxwb5xpwa) are lacking keys like
`artistId`. Make sure a key exists before trying to scrub it.