### PR TITLE
Mobileclient playlist fixes and changes

### DIFF
--- a/docs/source/reference/mobileclient.rst
+++ b/docs/source/reference/mobileclient.rst
@@ -37,6 +37,7 @@ entire library (not just their containing playlist).
 .. automethod:: Mobileclient.get_all_user_playlist_contents
 .. automethod:: Mobileclient.create_playlist
 .. automethod:: Mobileclient.delete_playlist
+.. automethod:: Mobileclient.edit_playlist
 .. automethod:: Mobileclient.add_songs_to_playlist
 .. automethod:: Mobileclient.reorder_playlist_entry
 .. automethod:: Mobileclient.remove_entries_from_playlist

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -282,16 +282,18 @@ class Mobileclient(_Base):
 
     # these could trivially support multiple creation/deletion, but
     # I chose to match the old webclient interface (at least for now).
-    def create_playlist(self, name, public=False):
+    def create_playlist(self, name, description=None, public=False):
         """Creates a new empty playlist and returns its id.
 
         :param name: the desired title.
           Creating multiple playlists with the same name is allowed.
+        :param description: (optional) the desired description
         :param public: if True, create a public All Access playlist.
         """
 
         mutate_call = mobileclient.BatchMutatePlaylists
         add_mutations = mutate_call.build_playlist_adds([{'name': name,
+                                                          'description': description,
                                                           'public': public}])
         res = self._make_call(mutate_call, add_mutations)
 

--- a/gmusicapi/clients/mobileclient.py
+++ b/gmusicapi/clients/mobileclient.py
@@ -291,10 +291,12 @@ class Mobileclient(_Base):
         :param public: if True, create a public All Access playlist.
         """
 
+        share_state = 'PUBLIC' if public else 'PRIVATE'
+
         mutate_call = mobileclient.BatchMutatePlaylists
         add_mutations = mutate_call.build_playlist_adds([{'name': name,
                                                           'description': description,
-                                                          'public': public}])
+                                                          'public': share_state}])
         res = self._make_call(mutate_call, add_mutations)
 
         return res['mutate_response'][0]['id']

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -596,12 +596,16 @@ class BatchMutatePlaylists(McBatchMutateCall):
         return [{'delete': id} for id in playlist_ids]
 
     @staticmethod
-    def build_playlist_updates(pl_id_name_pairs):
+    def build_playlist_updates(pl_updates):
         """
-        :param pl_id_name_pairs: [(playlist_id, new_name)]
+        :param pl_updates: [{'id': '', name': '', 'description': '', 'public': ''}]
         """
-        return [{'update': {'id': pl_id, 'name': new_name}} for
-                (pl_id, new_name) in pl_id_name_pairs]
+        return [{'update': {
+            'id': pl_update['id'],
+            'name': pl_update['name'],
+            'description': pl_update['description'],
+            'shareState': pl_update['public']
+        }} for pl_update in pl_updates]
 
     @staticmethod
     def build_playlist_adds(pl_descriptions):

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -101,6 +101,9 @@ sj_playlist = {
                       'required': False},
         'accessControlled': {'type': 'boolean',
                              'required': False},  # for public
+        'shareState': {'type': 'string',
+                       'pattern': r'PRIVATE|PUBLIC',
+                       'required': False},  # for public
         'creationTimestamp': {'type': 'string',
                               'required': False},  # for public
         'id': {'type': 'string',

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -606,7 +606,7 @@ class BatchMutatePlaylists(McBatchMutateCall):
     @staticmethod
     def build_playlist_adds(pl_descriptions):
         """
-        :param pl_descriptions: [{'name': '', 'public': <bool>}]
+        :param pl_descriptions: [{'name': '', 'description': '','public': <bool>}]
         """
 
         return [{'create': {
@@ -614,6 +614,7 @@ class BatchMutatePlaylists(McBatchMutateCall):
             'deleted': False,
             'lastModifiedTimestamp': '0',
             'name': pl_desc['name'],
+            'description': pl_desc['description'],
             'type': 'USER_GENERATED',
             'accessControlled': pl_desc['public'],
         }} for pl_desc in pl_descriptions]

--- a/gmusicapi/protocol/mobileclient.py
+++ b/gmusicapi/protocol/mobileclient.py
@@ -606,7 +606,7 @@ class BatchMutatePlaylists(McBatchMutateCall):
     @staticmethod
     def build_playlist_adds(pl_descriptions):
         """
-        :param pl_descriptions: [{'name': '', 'description': '','public': <bool>}]
+        :param pl_descriptions: [{'name': '', 'description': '','public': ''}]
         """
 
         return [{'create': {
@@ -616,7 +616,7 @@ class BatchMutatePlaylists(McBatchMutateCall):
             'name': pl_desc['name'],
             'description': pl_desc['description'],
             'type': 'USER_GENERATED',
-            'accessControlled': pl_desc['public'],
+            'shareState': pl_desc['public'],
         }} for pl_desc in pl_descriptions]
 
 

--- a/gmusicapi/test/server_tests.py
+++ b/gmusicapi/test/server_tests.py
@@ -271,7 +271,7 @@ class ClientTests(object):
 
     @test
     def playlist_create(self):
-        mc_id = self.mc.create_playlist(TEST_PLAYLIST_NAME)
+        mc_id = self.mc.create_playlist(TEST_PLAYLIST_NAME, "")
         wc_id = self.wc.create_playlist(TEST_PLAYLIST_NAME, "", public=True)
 
         # like song_create, retry until the playlist appears


### PR DESCRIPTION
* Change to shareState param from accessControlled as is now used and update calls as necessary.
* Add description param to Mobileclient.create_playlist.
* Remove change_playlist_name method.
* Add edit_playlist method to mirror Google's UI for changing name, description, and public/private.